### PR TITLE
LOR-229 - Filter tasks by shift

### DIFF
--- a/loryblu/LoryBlu.xcodeproj/project.pbxproj
+++ b/loryblu/LoryBlu.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		931D12D92B82C16F00589032 /* TaskNetworkModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931D12D82B82C16F00589032 /* TaskNetworkModels.swift */; };
 		931D12DB2B82C25300589032 /* TasksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931D12DA2B82C25300589032 /* TasksViewModel.swift */; };
 		9366FB182B6B063900A57F89 /* LBToolBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9366FB172B6B063900A57F89 /* LBToolBarModifier.swift */; };
+		93698CC62B89B9E7005EB154 /* TabRowShiftItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93698CC52B89B9E7005EB154 /* TabRowShiftItems.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -228,6 +229,7 @@
 		931D12D82B82C16F00589032 /* TaskNetworkModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskNetworkModels.swift; sourceTree = "<group>"; };
 		931D12DA2B82C25300589032 /* TasksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksViewModel.swift; sourceTree = "<group>"; };
 		9366FB172B6B063900A57F89 /* LBToolBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LBToolBarModifier.swift; sourceTree = "<group>"; };
+		93698CC52B89B9E7005EB154 /* TabRowShiftItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabRowShiftItems.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -664,6 +666,7 @@
 			children = (
 				9302EE912B71BFEA003D7C4F /* LBSelectedItemShift.swift */,
 				9302EE932B71C0C0003D7C4F /* LBShiftItemsComponent.swift */,
+				93698CC52B89B9E7005EB154 /* TabRowShiftItems.swift */,
 			);
 			path = ShiftsView;
 			sourceTree = "<group>";
@@ -885,6 +888,7 @@
 				8C2535322A7714DD0096738B /* RegisterResponsibleViewModel.swift in Sources */,
 				339573E32B87E37600E38B80 /* LBDaysButtonStyle.swift in Sources */,
 				9302EE942B71C0C0003D7C4F /* LBShiftItemsComponent.swift in Sources */,
+				93698CC62B89B9E7005EB154 /* TabRowShiftItems.swift in Sources */,
 				8C27B8542A68C19400F72214 /* LBLabel.swift in Sources */,
 				8C5DFC8F2A85AE13002739D9 /* LBToggle.swift in Sources */,
 				8C57341B2A6B4F5F0052B955 /* LBStrings.swift in Sources */,

--- a/loryblu/loryblu/Components/View/ShiftsView/LBShiftItemsComponent.swift
+++ b/loryblu/loryblu/Components/View/ShiftsView/LBShiftItemsComponent.swift
@@ -18,6 +18,8 @@ struct ShiftItem {
 struct LBShiftItemsComponent: View {
     
     let shifts: [ShiftItem]
+    var onClick: (String) -> Void = { _ in }
+    
     var body: some View {
         HStack {
             ForEach(shifts, id: \.name) { shift in
@@ -31,7 +33,8 @@ struct LBShiftItemsComponent: View {
                     Text(shift.name)
                         .font(LBFont.bodyLarge)
                         .foregroundColor(.gray)
-                        .frame(maxWidth: .infinity,alignment: .center)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .onTapGesture { onClick(shift.name) }
                 }
             }
         }

--- a/loryblu/loryblu/Components/View/ShiftsView/TabRowShiftItems.swift
+++ b/loryblu/loryblu/Components/View/ShiftsView/TabRowShiftItems.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+struct TabRowShiftItems: View {
+    @ObservedObject var viewmodel: TasksViewModel
+    var onSelect: (String) -> Void
+    var body: some View {
+        LBShiftItemsComponent(shifts: viewmodel.shifts, onClick: { shift in onSelect(shift) })
+    }
+}

--- a/loryblu/loryblu/Feature/Entities/TaskModel.swift
+++ b/loryblu/loryblu/Feature/Entities/TaskModel.swift
@@ -1,8 +1,10 @@
 import Foundation
+import SwiftUI
 
  struct TaskModel {
      var uuid: UUID = UUID()
      var actionType: String
      var locbookTask: LocbookTask
      var image: String
+     var backgroundCard: Color
 }

--- a/loryblu/loryblu/Feature/Entities/TaskNetworkModels.swift
+++ b/loryblu/loryblu/Feature/Entities/TaskNetworkModels.swift
@@ -1,11 +1,12 @@
 import Foundation
+import SwiftUI
 
-struct NetworkDataModel : Decodable {
+struct NetworkDataModel: Decodable {
     var study: [TasksNetworkModel]
     var routine: [TasksNetworkModel]
 }
 
-struct TasksNetworkModel : Decodable {
+struct TasksNetworkModel: Decodable {
     var id: Int
     var shift: String
     var frequency: [String]
@@ -17,20 +18,14 @@ struct TasksNetworkModel : Decodable {
 
 extension [TasksNetworkModel] {
     func toTasksModel(type: String) -> [TaskModel] {
-        let taskImages = switch type {
-        case LBStrings.Locbook.titleStudy : ListTasks.study
-        default :
-            ListTasks.rotine
-        }
-        
+        let taskImages = type == LBStrings.Locbook.titleStudy ? ListTasks.study : ListTasks.rotine
         return self.map { (task: TasksNetworkModel) -> TaskModel in
-            let shift = getShift(shift:task.shift)
-            let frequency = frequencyMapper(frequency:task.frequency)
+            let shift = getShift(shift: task.shift)
+            let frequency = frequencyMapper(frequency: task.frequency)
             let locbooktask = LocbookTask(childrenId: task.id, shift: shift,frequency: frequency, order: task.order, categoryId: task.categoryId,categoryTitle: task.categoryTitle,updatedAt: Date())
             let img = taskImages.filter { label in
                 label.categoryID == task.categoryId
             }.first
-            
             return task.toTaskModel(actionType: type, locbookTask: locbooktask, img: img!.image)
         }
     }
@@ -43,26 +38,43 @@ extension [TasksNetworkModel] {
     
     private func getFrequency(frequency: String) -> LocbookTask.Frequency {
         return switch frequency {
-        case "sun" : LocbookTask.Frequency.sun
-        case "mon" : LocbookTask.Frequency.mon
-        case "tue" : LocbookTask.Frequency.tue
-        case "wed" : LocbookTask.Frequency.wed
-        case "thu" : LocbookTask.Frequency.thu
-        case "fri" : LocbookTask.Frequency.fri
-        default : LocbookTask.Frequency.sat
+        case "sun": 
+            LocbookTask.Frequency.sun
+        case "mon": 
+            LocbookTask.Frequency.mon
+        case "tue": 
+            LocbookTask.Frequency.tue
+        case "wed": 
+            LocbookTask.Frequency.wed
+        case "thu":
+            LocbookTask.Frequency.thu
+        case "fri": 
+            LocbookTask.Frequency.fri
+        default: 
+            LocbookTask.Frequency.sat
         }
     }
     private func getShift(shift: String) -> LocbookTask.Shift {
         return switch shift {
-        case "morning" : LocbookTask.Shift.morning
-        case "afternoon" : LocbookTask.Shift.afternoon
-        default :
+        case "morning": 
+            LocbookTask.Shift.morning
+        case "afternoon": 
+            LocbookTask.Shift.afternoon
+        default:
             LocbookTask.Shift.night
         }
     }
 }
 extension TasksNetworkModel {
-    func toTaskModel(actionType:String, locbookTask: LocbookTask, img : String) -> TaskModel {
-        return TaskModel(actionType: actionType, locbookTask: locbookTask, image: img)
+    func toTaskModel(actionType: String, locbookTask: LocbookTask, img: String) -> TaskModel {
+        let backgroundCardColor: Color = switch locbookTask.shift {
+        case LocbookTask.Shift.morning?:
+            LBColor.buttonBackgroundLight
+        case LocbookTask.Shift.afternoon?:
+            LBColor.buttonBackgroundMedium
+        default:
+            LBColor.buttonBackgroundDark
+        }
+        return TaskModel(actionType: actionType, locbookTask: locbookTask, image: img, backgroundCard: backgroundCardColor)
     }
 }

--- a/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
+++ b/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
@@ -75,17 +75,18 @@ extension TasksViewModel {
                     LocbookTask.Frequency.fri,
                     LocbookTask.Frequency.sat]
         var count = 0
-        while(tasksFiltered == nil) {
+        while tasksFiltered == nil {
             let actualTasks = tasks.filter({ task in
                 Set([week[count]]).intersection(Set(task.locbookTask.frequency ?? [])).isEmpty == false
             })
-            if(!actualTasks.isEmpty) {
+            if !actualTasks.isEmpty {
                 tasksFiltered = actualTasks
+                dayDefault = tasksFiltered != nil ? week[count] : LocbookTask.Frequency.sun
             }
-            if(count == week.count && tasksFiltered == nil) {
+            if count == week.count && tasksFiltered == nil {
                 tasksFiltered = []
+                dayDefault = tasksFiltered != nil ? week[count - 1] : LocbookTask.Frequency.sun
             }
-            dayDefault = tasksFiltered != nil ? week[count] : LocbookTask.Frequency.sun
             count += 1
         }
         return (defaultDay: dayDefault!, tasksFiltered: tasksFiltered ?? [])
@@ -95,23 +96,24 @@ extension TasksViewModel {
         var shiftDefault: LocbookTask.Shift = LocbookTask.Shift.morning
         var shiftsItems = [LocbookTask.Shift.morning, LocbookTask.Shift.afternoon, LocbookTask.Shift.night]
         var count = 0
-        while(tasksFiltered == nil) {
+        while tasksFiltered == nil {
             let actualTasks = tasks.filter({ task in
                 task.locbookTask.shift == shiftsItems[count]
             })
-            if(!actualTasks.isEmpty) {
+            if !actualTasks.isEmpty {
                 tasksFiltered = actualTasks
+                shiftDefault = tasksFiltered != nil ? shiftsItems[count] : shiftDefault
             }
-            if(count == shiftsItems.count && tasksFiltered == nil) {
+            if count == shiftsItems.count && tasksFiltered == nil {
                 tasksFiltered = []
+                shiftDefault = tasksFiltered != nil ? shiftsItems[count - 1] : shiftDefault
             }
-            shiftDefault = tasksFiltered != nil ? shiftsItems[count] : shiftDefault
             count += 1
         }
         return (defaultShift: shiftDefault, tasksFiltered: tasksFiltered ?? [])
     }
     func getShiftsSelectedByDefault(shiftSelected: LocbookTask.Shift) -> [ShiftItem] {
-        var items = [ShiftItem(
+        let items = [ShiftItem(
             name: LBStrings.FrequencyRotine.morning,
             icon: LBIcon.sunSmall.rawValue,
             backgroundColor: LBColor.buttonBackgroundLight,
@@ -135,7 +137,7 @@ extension TasksViewModel {
             default:
                 LBStrings.FrequencyRotine.night
             }
-            var isSelected = shiftText == shift.name ? true : false
+            let isSelected = shiftText == shift.name ? true : false
             return ShiftItem(
                 name: shift.name,
                 icon: shift.icon,

--- a/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
+++ b/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
@@ -19,13 +19,32 @@ class TasksViewModel: ObservableObject {
     func filterWeekDay(weekDays: [LocbookTask.Frequency]) {
            var taskFiltered: [TaskModel] = []
 
-           if weekDays == [] {
-               self.tasks = listTask
-           } else {
-               taskFiltered = listTask.filter({ task in
-                   Set(weekDays).intersection(Set(task.locbookTask.frequency ?? [])).isEmpty == false
-               })
-               self.tasks = taskFiltered
-           }
-       }
- }
+extension TasksViewModel {
+    func pairDefaultDayNTasks(tasks: [TaskModel]) async ->
+    (defaultDay: LocbookTask.Frequency, tasksFiltered: [TaskModel]) {
+        var tasksFilted: [TaskModel]?
+        var dayDefault: LocbookTask.Frequency?
+        let week = [LocbookTask.Frequency.sun,
+                    LocbookTask.Frequency.mon,
+                    LocbookTask.Frequency.tue,
+                    LocbookTask.Frequency.wed,
+                    LocbookTask.Frequency.thu,
+                    LocbookTask.Frequency.fri,
+                    LocbookTask.Frequency.sat]
+        var count = 0
+        while(tasksFilted == nil) {
+            let actualTasks = tasks.filter({ task in
+                Set([week[count]]).intersection(Set(task.locbookTask.frequency ?? [])).isEmpty == false
+            })
+            if(!actualTasks.isEmpty) {
+                tasksFilted = tasks
+            }
+            if(count == week.count && tasksFilted == nil) {
+                tasksFilted = []
+            }
+            dayDefault = tasksFilted != nil ? week[count] : LocbookTask.Frequency.sun
+            count += 1
+        }
+        return (defaultDay: dayDefault!, tasksFiltered: tasksFilted ?? [])
+    }
+}

--- a/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
+++ b/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
@@ -85,7 +85,6 @@ extension TasksViewModel {
             }
             if count == week.count && tasksFiltered == nil {
                 tasksFiltered = []
-                dayDefault = tasksFiltered != nil ? week[count - 1] : LocbookTask.Frequency.sun
             }
             count += 1
         }
@@ -106,7 +105,6 @@ extension TasksViewModel {
             }
             if count == shiftsItems.count && tasksFiltered == nil {
                 tasksFiltered = []
-                shiftDefault = tasksFiltered != nil ? shiftsItems[count - 1] : shiftDefault
             }
             count += 1
         }

--- a/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
+++ b/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
@@ -7,14 +7,14 @@ class TasksViewModel: ObservableObject {
     private var cacheTasks: [TaskModel] = []
     @Published var tasks: [TaskModel] = []
     @Published var shifts: [ShiftItem] = []
-    private var currentSelectedShift: LocbookTask.Shift?
-    @Published var currentSelectedDay: LocbookTask.Frequency?
+    private var currentSelectedShift: LocbookTask.Shift? = nil
+    @Published var currentSelectedDay: LocbookTask.Frequency? = nil
     @Published var filteredTasks: [TaskModel] = []
     @MainActor
     func fetchTasks() async {
         cacheTasks = await repository.fetchTasks(token: appData.token, childrenId: appData.childrenId)
-        var pairDay = await pairDefaultDayNTasks(tasks: cacheTasks)
-        var pairShift = await pairDefaultShiftNTasks(tasks: pairDay.tasksFiltered)
+        let pairDay = await pairDefaultDayNTasks(tasks: cacheTasks)
+        let pairShift = await pairDefaultShiftNTasks(tasks: pairDay.tasksFiltered)
         currentSelectedDay = pairDay.defaultDay
         currentSelectedShift = pairShift.defaultShift
         shifts = getShiftsSelectedByDefault(shiftSelected: pairShift.defaultShift)
@@ -32,7 +32,6 @@ class TasksViewModel: ObservableObject {
             self.tasks = taskFiltered
         }
     }
-    
     func filterByShifts(shiftSelected: String) {
         currentSelectedShift = switch shiftSelected {
         case LBStrings.FrequencyRotine.morning:
@@ -61,7 +60,7 @@ class TasksViewModel: ObservableObject {
 extension TasksViewModel {
     func pairDefaultDayNTasks(tasks: [TaskModel]) async ->
     (defaultDay: LocbookTask.Frequency, tasksFiltered: [TaskModel]) {
-        var tasksFilted: [TaskModel]?
+        var tasksFiltered: [TaskModel]?
         var dayDefault: LocbookTask.Frequency?
         let week = [LocbookTask.Frequency.sun,
                     LocbookTask.Frequency.mon,
@@ -71,40 +70,40 @@ extension TasksViewModel {
                     LocbookTask.Frequency.fri,
                     LocbookTask.Frequency.sat]
         var count = 0
-        while(tasksFilted == nil) {
+        while(tasksFiltered == nil) {
             let actualTasks = tasks.filter({ task in
                 Set([week[count]]).intersection(Set(task.locbookTask.frequency ?? [])).isEmpty == false
             })
             if(!actualTasks.isEmpty) {
-                tasksFilted = tasks
+                tasksFiltered = actualTasks
             }
-            if(count == week.count && tasksFilted == nil) {
-                tasksFilted = []
+            if(count == week.count && tasksFiltered == nil) {
+                tasksFiltered = []
             }
-            dayDefault = tasksFilted != nil ? week[count] : LocbookTask.Frequency.sun
+            dayDefault = tasksFiltered != nil ? week[count] : LocbookTask.Frequency.sun
             count += 1
         }
-        return (defaultDay: dayDefault!, tasksFiltered: tasksFilted ?? [])
+        return (defaultDay: dayDefault!, tasksFiltered: tasksFiltered ?? [])
     }
     func pairDefaultShiftNTasks(tasks: [TaskModel]) async -> (defaultShift: LocbookTask.Shift, tasksFiltered: [TaskModel]) {
-        var tasksFilted: [TaskModel]?
+        var tasksFiltered: [TaskModel]?
         var shiftDefault: LocbookTask.Shift = LocbookTask.Shift.morning
         var shiftsItems = [LocbookTask.Shift.morning, LocbookTask.Shift.afternoon, LocbookTask.Shift.night]
         var count = 0
-        while(tasksFilted == nil) {
+        while(tasksFiltered == nil) {
             let actualTasks = tasks.filter({ task in
                 task.locbookTask.shift == shiftsItems[count]
             })
             if(!actualTasks.isEmpty) {
-                tasksFilted = tasks
+                tasksFiltered = actualTasks
             }
-            if(count == shiftsItems.count && tasksFilted == nil) {
-                tasksFilted = []
+            if(count == shiftsItems.count && tasksFiltered == nil) {
+                tasksFiltered = []
             }
-            shiftDefault = tasksFilted != nil ? shiftsItems[count] : shiftDefault
+            shiftDefault = tasksFiltered != nil ? shiftsItems[count] : shiftDefault
             count += 1
         }
-        return (defaultShift: shiftDefault, tasksFiltered: tasksFilted ?? [])
+        return (defaultShift: shiftDefault, tasksFiltered: tasksFiltered ?? [])
     }
     func getShiftsSelectedByDefault(shiftSelected: LocbookTask.Shift) -> [ShiftItem] {
         var items = [ShiftItem(

--- a/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
+++ b/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
@@ -67,4 +67,39 @@ extension TasksViewModel {
         }
         return (defaultShift: shiftDefault, tasksFiltered: tasksFilted ?? [])
     }
+    func getShiftsSelectedByDefault(shiftSelected: LocbookTask.Shift) -> [ShiftItem] {
+        var items = [ShiftItem(
+            name: LBStrings.FrequencyRotine.morning,
+            icon: LBIcon.sunSmall.rawValue,
+            backgroundColor: LBColor.buttonBackgroundLight,
+            letterColor: .black, isSelected: false),
+                     ShiftItem(
+                        name: LBStrings.FrequencyRotine.afternoon,
+                        icon: LBIcon.eviningSmall.rawValue,
+                        backgroundColor: LBColor.buttonBackgroundMedium,
+                        letterColor: .white, isSelected: false),
+                     ShiftItem(
+                        name: LBStrings.FrequencyRotine.night,
+                        icon: LBIcon.moonSmall.rawValue,
+                        backgroundColor: LBColor.buttonBackgroundDark,
+                        letterColor: .white, isSelected: false)]
+        return items.map { (shift: ShiftItem) -> ShiftItem in
+            let shiftText = switch shiftSelected {
+            case LocbookTask.Shift.morning:
+                LBStrings.FrequencyRotine.morning
+            case LocbookTask.Shift.afternoon:
+                LBStrings.FrequencyRotine.afternoon
+            default:
+                LBStrings.FrequencyRotine.night
+            }
+            var isSelected = shiftText == shift.name ? true : false
+            return ShiftItem(
+                name: shift.name,
+                icon: shift.icon,
+                backgroundColor: shift.backgroundColor,
+                letterColor: shift.letterColor,
+                isSelected: isSelected
+            )
+        }
+    }
 }

--- a/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
+++ b/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
@@ -47,4 +47,24 @@ extension TasksViewModel {
         }
         return (defaultDay: dayDefault!, tasksFiltered: tasksFilted ?? [])
     }
+    func pairDefaultShiftNTasks(tasks: [TaskModel]) async -> (defaultShift: LocbookTask.Shift, tasksFiltered: [TaskModel]) {
+        var tasksFilted: [TaskModel]?
+        var shiftDefault: LocbookTask.Shift = LocbookTask.Shift.morning
+        var shiftsItems = [LocbookTask.Shift.morning, LocbookTask.Shift.afternoon, LocbookTask.Shift.night]
+        var count = 0
+        while(tasksFilted == nil) {
+            let actualTasks = tasks.filter({ task in
+                task.locbookTask.shift == shiftsItems[count]
+            })
+            if(!actualTasks.isEmpty) {
+                tasksFilted = tasks
+            }
+            if(count == shiftsItems.count && tasksFilted == nil) {
+                tasksFilted = []
+            }
+            shiftDefault = tasksFilted != nil ? shiftsItems[count] : shiftDefault
+            count += 1
+        }
+        return (defaultShift: shiftDefault, tasksFiltered: tasksFilted ?? [])
+    }
 }

--- a/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
+++ b/loryblu/loryblu/Feature/Locbook/Model/TasksViewModel.swift
@@ -21,7 +21,42 @@ class TasksViewModel: ObservableObject {
         tasks = pairShift.tasksFiltered
     }
     func filterWeekDay(weekDays: [LocbookTask.Frequency]) {
-           var taskFiltered: [TaskModel] = []
+        var taskFiltered: [TaskModel] = []
+        currentSelectedDay = weekDays.first ?? .sun
+        if weekDays == [] {
+            self.tasks = cacheTasks
+        } else {
+            taskFiltered = cacheTasks.filter({ task in
+                Set(weekDays).intersection(Set(task.locbookTask.frequency ?? [])).isEmpty == false && task.locbookTask.shift == currentSelectedShift
+            })
+            self.tasks = taskFiltered
+        }
+    }
+    
+    func filterByShifts(shiftSelected: String) {
+        currentSelectedShift = switch shiftSelected {
+        case LBStrings.FrequencyRotine.morning:
+            LocbookTask.Shift.morning
+        case LBStrings.FrequencyRotine.afternoon:
+            LocbookTask.Shift.afternoon
+        default:
+            LocbookTask.Shift.night
+        }
+        shifts = shifts.map { (shift: ShiftItem) -> ShiftItem in
+            let isSelected = shiftSelected == shift.name ? true : false
+            return ShiftItem(
+                name: shift.name,
+                icon: shift.icon,
+                backgroundColor: shift.backgroundColor,
+                letterColor: shift.letterColor,
+                isSelected: isSelected
+            )
+        }
+        tasks = cacheTasks.filter({ task in
+            Set([currentSelectedDay]).intersection(Set(task.locbookTask.frequency ?? [])).isEmpty == false && task.locbookTask.shift == currentSelectedShift
+        })
+    }
+}
 
 extension TasksViewModel {
     func pairDefaultDayNTasks(tasks: [TaskModel]) async ->

--- a/loryblu/loryblu/Feature/Locbook/View/LocbookListTasksView.swift
+++ b/loryblu/loryblu/Feature/Locbook/View/LocbookListTasksView.swift
@@ -33,7 +33,7 @@ struct LocbookListTasksView: View {
     var body: some View {
         VStack {
             VStack(spacing: 16) {
-                LBFrequencyFilter(day: day, viewmodel: viewmodel)
+                LBFrequencyFilter(viewmodel: viewmodel)
 
                 LBShiftItemsComponent(shifts: shiftsEXEMPLO)
             }
@@ -114,7 +114,6 @@ struct LBFrequencyFilter: View {
         case none
     }
 
-    @State var day: Week
     @ObservedObject var viewmodel: TasksViewModel
 
     var body: some View {
@@ -125,39 +124,32 @@ struct LBFrequencyFilter: View {
 
             HStack(spacing: 20) {
                 Button("D") {
-                    day = .sunday
                     viewmodel.filterWeekDay(weekDays: [.sun])
-                }.buttonStyle(LBDaysButtonStyle(isSet: day == .sunday ))
+                }.buttonStyle(LBDaysButtonStyle(isSet: viewmodel.currentSelectedDay == .sun ))
 
                 Button("S") {
-                    day = .monday
                     viewmodel.filterWeekDay(weekDays: [.mon])
-                }.buttonStyle(LBDaysButtonStyle(isSet: day == .monday))
+                }.buttonStyle(LBDaysButtonStyle(isSet: viewmodel.currentSelectedDay == .mon))
 
                 Button("T") {
-                    day = .tuesday
                     viewmodel.filterWeekDay(weekDays: [.tue])
-                }.buttonStyle(LBDaysButtonStyle(isSet: day == .tuesday))
+                }.buttonStyle(LBDaysButtonStyle(isSet: viewmodel.currentSelectedDay == .tue))
 
                 Button("Q") {
-                    day = .wednesday
                     viewmodel.filterWeekDay(weekDays: [.wed])
-                }.buttonStyle(LBDaysButtonStyle(isSet: day == .wednesday))
+                }.buttonStyle(LBDaysButtonStyle(isSet: viewmodel.currentSelectedDay == .wed))
 
                 Button("Q") {
-                    day = .thurday
                     viewmodel.filterWeekDay(weekDays: [.thu])
-                }.buttonStyle(LBDaysButtonStyle(isSet: day == .thurday))
+                }.buttonStyle(LBDaysButtonStyle(isSet: viewmodel.currentSelectedDay == .thu))
 
                 Button("S") {
-                    day = .friday
                     viewmodel.filterWeekDay(weekDays: [.fri])
-                }.buttonStyle(LBDaysButtonStyle(isSet: day == .friday))
+                }.buttonStyle(LBDaysButtonStyle(isSet: viewmodel.currentSelectedDay == .fri))
 
                 Button("S") {
-                    day = .satuday
                     viewmodel.filterWeekDay(weekDays: [.sat])
-                }.buttonStyle(LBDaysButtonStyle(isSet: day == .satuday))
+                }.buttonStyle(LBDaysButtonStyle(isSet: viewmodel.currentSelectedDay == .sat))
             }
         }
     }

--- a/loryblu/loryblu/Feature/Locbook/View/LocbookListTasksView.swift
+++ b/loryblu/loryblu/Feature/Locbook/View/LocbookListTasksView.swift
@@ -3,25 +3,6 @@ import SwiftUI
 struct LocbookListTasksView: View {
     @State private var securityIsOn = true
 
-    // TODO: Implementar funcionalidade e filtro
-    let shiftsEXEMPLO = [
-        ShiftItem(
-            name: LBStrings.FrequencyRotine.morning,
-            icon: LBIcon.sunSmall.rawValue,
-            backgroundColor: LBColor.buttonBackgroundLight,
-            letterColor: .black, isSelected: false),
-        ShiftItem(
-            name: LBStrings.FrequencyRotine.afternoon,
-            icon: LBIcon.eviningSmall.rawValue,
-            backgroundColor: LBColor.buttonBackgroundMedium,
-            letterColor: .white, isSelected: true),
-        ShiftItem(
-            name: LBStrings.FrequencyRotine.night,
-            icon: LBIcon.moonSmall.rawValue,
-            backgroundColor: LBColor.buttonBackgroundDark,
-            letterColor: .white, isSelected: false)
-    ]
-
     struct Props {
         let onNewTask: ClosureType.VoidVoid?
     }
@@ -35,7 +16,10 @@ struct LocbookListTasksView: View {
             VStack(spacing: 16) {
                 LBFrequencyFilter(viewmodel: viewmodel)
 
-                LBShiftItemsComponent(shifts: shiftsEXEMPLO)
+                TabRowShiftItems(
+                    viewmodel: viewmodel,
+                    onSelect: { shift in viewmodel.filterByShifts(shiftSelected: shift) }
+                )
             }
             .padding(.init(top: 16, leading: 24, bottom: 0, trailing: 24))
 

--- a/loryblu/loryblu/Feature/Locbook/View/LocbookListTasksView.swift
+++ b/loryblu/loryblu/Feature/Locbook/View/LocbookListTasksView.swift
@@ -91,7 +91,7 @@ struct ListTasksView: View {
                         nameAction: model.actionType,
                         imageTask: model.image,
                         nameTask: model.locbookTask.categoryTitle ?? "",
-                        backgroundCard: LBColor.buttonBackgroundLight, isSecurity: .constant(securityIsOn))
+                        backgroundCard: model.backgroundCard, isSecurity: .constant(securityIsOn))
                 }
                 .listRowSeparator(.hidden)
             }


### PR DESCRIPTION
## What's this PR doing?

- [X] Enable the user select on shift items component
- [X] The user could filter tasks based on shift and day selected
- [X] By default, the system retrieves tasks based on the first day of the week. If no tasks are found, it moves to the next day and continues in the same manner. The same process is then applied to the filtered shifts.
- [X] When the user moves to the next screen, the current filter is saved, ensuring that if the user returns to the previous screen, the last selected filter is preserved.

## Preview
![Simulator Screen Recording - iPhone 15 Pro - 2024-02-24 at 03 14 33](https://github.com/loryblu/loryblu-ios/assets/72306040/b11c8d57-2a79-43d0-9cb2-b3ae63325b95)
